### PR TITLE
Use `rem` instead of `px`

### DIFF
--- a/packages/site/src/components/Buttons.tsx
+++ b/packages/site/src/components/Buttons.tsx
@@ -15,7 +15,7 @@ const Link = styled.a`
   color: ${(props) => props.theme.colors.text.inverse};
   text-decoration: none;
   font-weight: bold;
-  padding: 0.625rem;
+  padding: 1rem;
   cursor: pointer;
   transition: all 0.2s ease-in-out;
 
@@ -42,7 +42,7 @@ const Button = styled.button`
 `;
 
 const ButtonText = styled.span`
-  margin-left: 0.625rem;
+  margin-left: 1rem;
 `;
 
 const ConnectedContainer = styled.div`
@@ -56,7 +56,7 @@ const ConnectedContainer = styled.div`
   background-color: ${(props) => props.theme.colors.background.inverse};
   color: ${(props) => props.theme.colors.text.inverse};
   font-weight: bold;
-  padding: 0.75rem;
+  padding: 1.2rem;
 `;
 
 const ConnectedIndicator = styled.div`

--- a/packages/site/src/components/Buttons.tsx
+++ b/packages/site/src/components/Buttons.tsx
@@ -15,7 +15,7 @@ const Link = styled.a`
   color: ${(props) => props.theme.colors.text.inverse};
   text-decoration: none;
   font-weight: bold;
-  padding: 10px;
+  padding: 0.625rem;
   cursor: pointer;
   transition: all 0.2s ease-in-out;
 
@@ -42,7 +42,7 @@ const Button = styled.button`
 `;
 
 const ButtonText = styled.span`
-  margin-left: 10px;
+  margin-left: 0.625rem;
 `;
 
 const ConnectedContainer = styled.div`
@@ -56,7 +56,7 @@ const ConnectedContainer = styled.div`
   background-color: ${(props) => props.theme.colors.background.inverse};
   color: ${(props) => props.theme.colors.text.inverse};
   font-weight: bold;
-  padding: 12px;
+  padding: 0.75rem;
 `;
 
 const ConnectedIndicator = styled.div`

--- a/packages/site/src/components/Card.tsx
+++ b/packages/site/src/components/Card.tsx
@@ -16,9 +16,9 @@ const CardWrapper = styled.div<{ fullWidth?: boolean; disabled: boolean }>`
   flex-direction: column;
   width: ${({ fullWidth }) => (fullWidth ? '100%' : '250px')};
   background-color: ${({ theme }) => theme.colors.card.default};
-  margin-top: 1.5rem;
-  margin-bottom: 1.5rem;
-  padding: 1.5rem;
+  margin-top: 2.4rem;
+  margin-bottom: 2.4rem;
+  padding: 2.4rem;
   border: 1px solid ${({ theme }) => theme.colors.border.default};
   border-radius: ${({ theme }) => theme.radii.default};
   box-shadow: ${({ theme }) => theme.shadows.default};
@@ -26,9 +26,9 @@ const CardWrapper = styled.div<{ fullWidth?: boolean; disabled: boolean }>`
   align-self: stretch;
   ${({ theme }) => theme.mediaQueries.small} {
     width: 100%;
-    margin-top: 0.75rem;
-    margin-bottom: 0.75rem;
-    padding: 1rem;
+    margin-top: 1.2rem;
+    margin-bottom: 1.2rem;
+    padding: 1.6rem;
   }
 `;
 
@@ -41,8 +41,8 @@ const Title = styled.h2`
 `;
 
 const Description = styled.p`
-  margin-top: 1.5rem;
-  margin-bottom: 1.5rem;
+  margin-top: 2.4rem;
+  margin-bottom: 2.4rem;
 `;
 
 export const Card = ({ content, disabled = false, fullWidth }: CardProps) => {

--- a/packages/site/src/components/Card.tsx
+++ b/packages/site/src/components/Card.tsx
@@ -16,9 +16,9 @@ const CardWrapper = styled.div<{ fullWidth?: boolean; disabled: boolean }>`
   flex-direction: column;
   width: ${({ fullWidth }) => (fullWidth ? '100%' : '250px')};
   background-color: ${({ theme }) => theme.colors.card.default};
-  margin-top: 24px;
-  margin-bottom: 24px;
-  padding: 24px;
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  padding: 1.5rem;
   border: 1px solid ${({ theme }) => theme.colors.border.default};
   border-radius: ${({ theme }) => theme.radii.default};
   box-shadow: ${({ theme }) => theme.shadows.default};
@@ -26,9 +26,9 @@ const CardWrapper = styled.div<{ fullWidth?: boolean; disabled: boolean }>`
   align-self: stretch;
   ${({ theme }) => theme.mediaQueries.small} {
     width: 100%;
-    margin-top: 12px;
-    margin-bottom: 12px;
-    padding: 16px;
+    margin-top: 0.75rem;
+    margin-bottom: 0.75rem;
+    padding: 1rem;
   }
 `;
 
@@ -36,13 +36,13 @@ const Title = styled.h2`
   font-size: ${({ theme }) => theme.fontSizes.large};
   margin: 0;
   ${({ theme }) => theme.mediaQueries.small} {
-    font-size: 16px;
+    font-size: ${({ theme }) => theme.fontSizes.text};
   }
 `;
 
 const Description = styled.p`
-  margin-top: 24px;
-  margin-bottom: 24px;
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
 `;
 
 export const Card = ({ content, disabled = false, fullWidth }: CardProps) => {

--- a/packages/site/src/components/Footer.tsx
+++ b/packages/site/src/components/Footer.tsx
@@ -8,8 +8,8 @@ const FooterWrapper = styled.footer`
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  padding-top: 24px;
-  padding-bottom: 24px;
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
   border-top: 1px solid ${(props) => props.theme.colors.border.default};
 `;
 
@@ -18,7 +18,7 @@ const PoweredByButton = styled.a`
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  padding: 12px;
+  padding: 0.75rem;
   border-radius: ${({ theme }) => theme.radii.button};
   box-shadow: ${({ theme }) => theme.shadows.button};
   background-color: ${({ theme }) => theme.colors.background.alternative};
@@ -27,7 +27,7 @@ const PoweredByButton = styled.a`
 const PoweredByContainer = styled.div`
   display: flex;
   flex-direction: column;
-  margin-left: 10px;
+  margin-left: 0.625rem;
 `;
 
 export const Footer = () => {

--- a/packages/site/src/components/Footer.tsx
+++ b/packages/site/src/components/Footer.tsx
@@ -8,8 +8,8 @@ const FooterWrapper = styled.footer`
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  padding-top: 1.5rem;
-  padding-bottom: 1.5rem;
+  padding-top: 2.4rem;
+  padding-bottom: 2.4rem;
   border-top: 1px solid ${(props) => props.theme.colors.border.default};
 `;
 
@@ -18,7 +18,7 @@ const PoweredByButton = styled.a`
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  padding: 0.75rem;
+  padding: 1.2rem;
   border-radius: ${({ theme }) => theme.radii.button};
   box-shadow: ${({ theme }) => theme.shadows.button};
   background-color: ${({ theme }) => theme.colors.background.alternative};
@@ -27,7 +27,7 @@ const PoweredByButton = styled.a`
 const PoweredByContainer = styled.div`
   display: flex;
   flex-direction: column;
-  margin-left: 0.625rem;
+  margin-left: 1rem;
 `;
 
 export const Footer = () => {

--- a/packages/site/src/components/Header.tsx
+++ b/packages/site/src/components/Header.tsx
@@ -11,7 +11,7 @@ const HeaderWrapper = styled.header`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  padding: 1.5rem;
+  padding: 2.4rem;
   border-bottom: 1px solid ${(props) => props.theme.colors.border.default};
 `;
 
@@ -19,7 +19,7 @@ const Title = styled.p`
   font-size: ${(props) => props.theme.fontSizes.title};
   font-weight: bold;
   margin: 0;
-  margin-left: 0.75rem;
+  margin-left: 1.2rem;
   ${({ theme }) => theme.mediaQueries.small} {
     display: none;
   }

--- a/packages/site/src/components/Header.tsx
+++ b/packages/site/src/components/Header.tsx
@@ -11,7 +11,7 @@ const HeaderWrapper = styled.header`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  padding: 24px;
+  padding: 1.5rem;
   border-bottom: 1px solid ${(props) => props.theme.colors.border.default};
 `;
 
@@ -19,7 +19,7 @@ const Title = styled.p`
   font-size: ${(props) => props.theme.fontSizes.title};
   font-weight: bold;
   margin: 0;
-  margin-left: 12px;
+  margin-left: 0.75rem;
   ${({ theme }) => theme.mediaQueries.small} {
     display: none;
   }

--- a/packages/site/src/components/Home.tsx
+++ b/packages/site/src/components/Home.tsx
@@ -10,20 +10,20 @@ const Container = styled.div`
   flex-direction: column;
   align-items: center;
   flex: 1;
-  margin-top: 76px;
-  margin-bottom: 76px;
+  margin-top: 4.75rem;
+  margin-bottom: 4.75rem;
   ${({ theme }) => theme.mediaQueries.small} {
-    padding-left: 24px;
-    padding-right: 24px;
-    margin-top: 20px;
-    margin-bottom: 20px;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+    margin-top: 1.25rem;
+    margin-bottom: 1.25rem;
     width: auto;
   }
 `;
 
 const Heading = styled.h1`
   margin-top: 0;
-  margin-bottom: 24px;
+  margin-bottom: 1.5rem;
   text-align: center;
 `;
 
@@ -32,12 +32,12 @@ const Span = styled.span`
 `;
 
 const Subtitle = styled.p`
-  font-size: 20px;
+  font-size: ${({ theme }) => theme.fontSizes.large};
   font-weight: 500;
   margin-top: 0;
   margin-bottom: 0;
   ${({ theme }) => theme.mediaQueries.small} {
-    font-size: ${({ theme }) => theme.fontSizes.default};
+    font-size: ${({ theme }) => theme.fontSizes.text};
   }
 `;
 
@@ -49,7 +49,7 @@ const CardContainer = styled.div`
   max-width: 648px;
   width: 100%;
   height: 100%;
-  margin-top: 24px;
+  margin-top: 1.5rem;
 `;
 
 const Notice = styled.div`
@@ -57,8 +57,8 @@ const Notice = styled.div`
   border: 1px solid ${({ theme }) => theme.colors.border.default};
   color: ${({ theme }) => theme.colors.text.alternative};
   border-radius: ${({ theme }) => theme.radii.default};
-  padding: 24px;
-  margin-top: 24px;
+  padding: 1.5rem;
+  margin-top: 1.5rem;
   max-width: 600px;
   width: 100%;
 
@@ -66,7 +66,7 @@ const Notice = styled.div`
     margin: 0;
   }
   ${({ theme }) => theme.mediaQueries.small} {
-    margin-top: 12px;
+    margin-top: 0.75rem;
     padding: 16px;
   }
 `;
@@ -76,15 +76,15 @@ const ErrorMessage = styled.div`
   border: 1px solid ${({ theme }) => theme.colors.error.default};
   color: ${({ theme }) => theme.colors.error.alternative};
   border-radius: ${({ theme }) => theme.radii.default};
-  padding: 24px;
-  margin-bottom: 24px;
-  margin-top: 24px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  margin-top: 1.5rem;
   max-width: 600px;
   width: 100%;
   ${({ theme }) => theme.mediaQueries.small} {
-    padding: 16px;
-    margin-bottom: 12px;
-    margin-top: 12px;
+    padding: 1rem;
+    margin-bottom: 0.75rem;
+    margin-top: 0.75rem;
     max-width: 100%;
   }
 `;

--- a/packages/site/src/components/Home.tsx
+++ b/packages/site/src/components/Home.tsx
@@ -10,20 +10,20 @@ const Container = styled.div`
   flex-direction: column;
   align-items: center;
   flex: 1;
-  margin-top: 4.75rem;
-  margin-bottom: 4.75rem;
+  margin-top: 7.6rem;
+  margin-bottom: 7.6rem;
   ${({ theme }) => theme.mediaQueries.small} {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
-    margin-top: 1.25rem;
-    margin-bottom: 1.25rem;
+    padding-left: 2.4rem;
+    padding-right: 2.4rem;
+    margin-top: 2rem;
+    margin-bottom: 2rem;
     width: auto;
   }
 `;
 
 const Heading = styled.h1`
   margin-top: 0;
-  margin-bottom: 1.5rem;
+  margin-bottom: 2.4rem;
   text-align: center;
 `;
 
@@ -46,7 +46,7 @@ const CardContainer = styled.div`
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: space-between;
-  max-width: 648px;
+  max-width: 64.8rem;
   width: 100%;
   height: 100%;
   margin-top: 1.5rem;
@@ -57,17 +57,17 @@ const Notice = styled.div`
   border: 1px solid ${({ theme }) => theme.colors.border.default};
   color: ${({ theme }) => theme.colors.text.alternative};
   border-radius: ${({ theme }) => theme.radii.default};
-  padding: 1.5rem;
-  margin-top: 1.5rem;
-  max-width: 600px;
+  padding: 2.4rem;
+  margin-top: 2.4rem;
+  max-width: 60rem;
   width: 100%;
 
   & > * {
     margin: 0;
   }
   ${({ theme }) => theme.mediaQueries.small} {
-    margin-top: 0.75rem;
-    padding: 16px;
+    margin-top: 1.2rem;
+    padding: 1.6rem;
   }
 `;
 
@@ -76,15 +76,15 @@ const ErrorMessage = styled.div`
   border: 1px solid ${({ theme }) => theme.colors.error.default};
   color: ${({ theme }) => theme.colors.error.alternative};
   border-radius: ${({ theme }) => theme.radii.default};
-  padding: 1.5rem;
-  margin-bottom: 1.5rem;
-  margin-top: 1.5rem;
-  max-width: 600px;
+  padding: 2.4rem;
+  margin-bottom: 2.4rem;
+  margin-top: 2.4rem;
+  max-width: 60rem;
   width: 100%;
   ${({ theme }) => theme.mediaQueries.small} {
-    padding: 1rem;
-    margin-bottom: 0.75rem;
-    margin-top: 0.75rem;
+    padding: 1.6rem;
+    margin-bottom: 1.2rem;
+    margin-top: 1.2rem;
     max-width: 100%;
   }
 `;

--- a/packages/site/src/components/Toggle.tsx
+++ b/packages/site/src/components/Toggle.tsx
@@ -19,9 +19,9 @@ const ToggleWrapper = styled.div`
   user-select: none;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   -webkit-tap-highlight-color: transparent;
-  margin-right: 1.5rem;
+  margin-right: 2.4rem;
   ${({ theme }) => theme.mediaQueries.small} {
-    margin-right: 0.75rem;
+    margin-right: 2.4rem;
   }
 `;
 

--- a/packages/site/src/components/Toggle.tsx
+++ b/packages/site/src/components/Toggle.tsx
@@ -19,9 +19,9 @@ const ToggleWrapper = styled.div`
   user-select: none;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   -webkit-tap-highlight-color: transparent;
-  margin-right: 24px;
+  margin-right: 1.5rem;
   ${({ theme }) => theme.mediaQueries.small} {
-    margin-right: 12px;
+    margin-right: 0.75rem;
   }
 `;
 

--- a/packages/site/src/config/theme.ts
+++ b/packages/site/src/config/theme.ts
@@ -12,13 +12,12 @@ const theme = {
     code: 'ui-monospace,Menlo,Monaco,"Cascadia Mono","Segoe UI Mono","Roboto Mono","Oxygen Mono","Ubuntu Monospace","Source Code Pro","Fira Mono","Droid Sans Mono","Courier New", monospace',
   },
   fontSizes: {
-    heading: '3.25rem',
-    mobileHeading: '2.25rem',
-    title: '1.5rem',
-    large: '1.25rem',
-    default: '16px',
-    text: '1rem',
-    small: '0.875rem',
+    heading: '5.2rem',
+    mobileHeading: '3.6rem',
+    title: '2.4rem',
+    large: '2rem',
+    text: '1.6rem',
+    small: '1.4rem',
   },
   radii: {
     default: '24px',
@@ -121,16 +120,17 @@ export const dark: DefaultTheme = {
  * @returns Global style React component.
  */
 export const GlobalStyle = createGlobalStyle`
+  html {
+    /* 62.5% of the base size of 16px = 10px.*/
+    font-size: 62.5%;
+  }
+
   body {
     background-color: ${(props) => props.theme.colors.background.default};
     color: ${(props) => props.theme.colors.text.default};
     font-family: ${(props) => props.theme.fonts.default};
-    font-size: ${(props) => props.theme.fontSizes.default};
-    margin: 0;
-  }
-
-  #root {
     font-size: ${(props) => props.theme.fontSizes.text};
+    margin: 0;
   }
 
   * {

--- a/packages/site/src/config/theme.ts
+++ b/packages/site/src/config/theme.ts
@@ -12,12 +12,13 @@ const theme = {
     code: 'ui-monospace,Menlo,Monaco,"Cascadia Mono","Segoe UI Mono","Roboto Mono","Oxygen Mono","Ubuntu Monospace","Source Code Pro","Fira Mono","Droid Sans Mono","Courier New", monospace',
   },
   fontSizes: {
-    heading: '52px',
-    mobileHeading: '36px',
-    title: '24px',
-    large: '20px',
+    heading: '3.25rem',
+    mobileHeading: '2.25rem',
+    title: '1.5rem',
+    large: '1.25rem',
     default: '16px',
-    small: '14px',
+    text: '1rem',
+    small: '0.875rem',
   },
   radii: {
     default: '24px',
@@ -128,6 +129,10 @@ export const GlobalStyle = createGlobalStyle`
     margin: 0;
   }
 
+  #root {
+    font-size: ${(props) => props.theme.fontSizes.text};
+  }
+
   * {
     transition: background-color .1s linear;
   }
@@ -142,9 +147,9 @@ export const GlobalStyle = createGlobalStyle`
   code {
     background-color: ${(props) => props.theme.colors.background.alternative};
     font-family: ${(props) => props.theme.fonts.code};
-    padding: 12px;
+    padding: 0.75rem;
     font-weight: normal;
-    font-size: ${(props) => props.theme.fontSizes.default};
+    font-size: ${(props) => props.theme.fontSizes.text};
   }
 
   button {
@@ -154,7 +159,7 @@ export const GlobalStyle = createGlobalStyle`
     color: ${(props) => props.theme.colors.text.inverse};
     border: 1px solid ${(props) => props.theme.colors.background.inverse};
     font-weight: bold;
-    padding: 10px;
+    padding: 0.625rem;
     min-height: 42px;
     cursor: pointer;
     transition: all .2s ease-in-out;

--- a/packages/site/src/config/theme.ts
+++ b/packages/site/src/config/theme.ts
@@ -147,7 +147,7 @@ export const GlobalStyle = createGlobalStyle`
   code {
     background-color: ${(props) => props.theme.colors.background.alternative};
     font-family: ${(props) => props.theme.fonts.code};
-    padding: 0.75rem;
+    padding: 1.2rem;
     font-weight: normal;
     font-size: ${(props) => props.theme.fontSizes.text};
   }
@@ -159,8 +159,8 @@ export const GlobalStyle = createGlobalStyle`
     color: ${(props) => props.theme.colors.text.inverse};
     border: 1px solid ${(props) => props.theme.colors.background.inverse};
     font-weight: bold;
-    padding: 0.625rem;
-    min-height: 42px;
+    padding: 1rem;
+    min-height: 4.2rem;
     cursor: pointer;
     transition: all .2s ease-in-out;
 


### PR DESCRIPTION
Use `rem` units instead of `px` on `font-size`, `padding` and `margin`.

Use [the 62.5% `font-size` trick](https://www.aleksandrhovhannisyan.com/blog/62-5-percent-font-size-trick) to facilitate use of `rem`. With this trick `1rem` = `10px`.

fixes: #2 