### PR TITLE
Require clean working directory

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,6 +33,13 @@ jobs:
       - run: yarn build
       - run: yarn lint
       - run: yarn test
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty after building"
+            exit 1
+          fi
   #      - name: Validate RC changelog
   #        if: ${{ startsWith(github.head_ref, 'release/') }}
   #        run: yarn auto-changelog validate --rc

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "ZowWdJLCOijpOFAdPXlXnzpqIq2L0pM3m+E/zgCKs/k=",
+    "shasum": "GbpXAntwgt11+Q6D/7MZYNgFRPzbV7lYzmb8DX9ojNo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
We should make sure the snap manifest is up to date as part of our CI process. Checking whether the working directory is clean is one way of doing that.