### PR TITLE
Show Reconnect button if the installed snap is a local snap

### DIFF
--- a/packages/site/src/components/Buttons.tsx
+++ b/packages/site/src/components/Buttons.tsx
@@ -2,6 +2,7 @@ import { ComponentProps } from 'react';
 import styled from 'styled-components';
 import { MetamaskState } from '../hooks';
 import { ReactComponent as FlaskFox } from '../assets/flask_fox.svg';
+import { isLocalSnap } from '../utils';
 
 const Link = styled.a`
   display: flex;
@@ -36,6 +37,7 @@ const Button = styled.button`
   align-self: flex-start;
   align-items: center;
   justify-content: center;
+  margin-top: auto;
   ${({ theme }) => theme.mediaQueries.small} {
     width: 100%;
   }
@@ -98,7 +100,7 @@ export const HeaderButtons = ({
     return <InstallFlaskButton />;
   }
 
-  if (!state.isSnapInstalled) {
+  if (state.snap && (isLocalSnap(state.snap?.id) || !state.isSnapInstalled)) {
     return <ConnectButton onClick={onConnectClick} />;
   }
 

--- a/packages/site/src/components/Buttons.tsx
+++ b/packages/site/src/components/Buttons.tsx
@@ -2,7 +2,7 @@ import { ComponentProps } from 'react';
 import styled from 'styled-components';
 import { MetamaskState } from '../hooks';
 import { ReactComponent as FlaskFox } from '../assets/flask_fox.svg';
-import { isLocalSnap } from '../utils';
+import { shouldDisplayReconnectButton } from '../utils';
 
 const Link = styled.a`
   display: flex;
@@ -105,15 +105,15 @@ export const HeaderButtons = ({
   state: MetamaskState;
   onConnectClick(): unknown;
 }) => {
-  if (!state.isFlask && !state.isSnapInstalled) {
+  if (!state.isFlask && !state.installedSnap) {
     return <InstallFlaskButton />;
   }
 
-  if (!state.isSnapInstalled) {
+  if (!state.installedSnap) {
     return <ConnectButton onClick={onConnectClick} />;
   }
 
-  if (state.snap && isLocalSnap(state.snap?.id)) {
+  if (shouldDisplayReconnectButton(state.installedSnap)) {
     return <ReconnectButton onClick={onConnectClick} />;
   }
 

--- a/packages/site/src/components/Buttons.tsx
+++ b/packages/site/src/components/Buttons.tsx
@@ -85,6 +85,15 @@ export const ConnectButton = (props: ComponentProps<typeof Button>) => {
   );
 };
 
+export const ReconnectButton = (props: ComponentProps<typeof Button>) => {
+  return (
+    <Button {...props}>
+      <FlaskFox />
+      <ButtonText>Reconnect</ButtonText>
+    </Button>
+  );
+};
+
 export const SendHelloButton = (props: ComponentProps<typeof Button>) => {
   return <Button {...props}>Send message</Button>;
 };
@@ -100,8 +109,12 @@ export const HeaderButtons = ({
     return <InstallFlaskButton />;
   }
 
-  if (state.snap && (isLocalSnap(state.snap?.id) || !state.isSnapInstalled)) {
+  if (!state.isSnapInstalled) {
     return <ConnectButton onClick={onConnectClick} />;
+  }
+
+  if (state.snap && isLocalSnap(state.snap?.id)) {
+    return <ReconnectButton onClick={onConnectClick} />;
   }
 
   return (

--- a/packages/site/src/components/Header.tsx
+++ b/packages/site/src/components/Header.tsx
@@ -52,10 +52,7 @@ export const Header = ({
 
       dispatch({
         type: MetamaskActions.SetInstalled,
-        payload: {
-          isSnapInstalled: Boolean(installedSnap),
-          snap: installedSnap,
-        },
+        payload: installedSnap,
       });
     } catch (e) {
       console.error(e);

--- a/packages/site/src/components/Header.tsx
+++ b/packages/site/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import styled, { useTheme } from 'styled-components';
 import { MetamaskActions, MetaMaskContext } from '../hooks';
-import { connectSnap, getThemePreference, isSnapInstalled } from '../utils';
+import { connectSnap, getThemePreference, getSnap } from '../utils';
 import { HeaderButtons } from './Buttons';
 import { SnapLogo } from './SnapLogo';
 import { Toggle } from './Toggle';
@@ -48,11 +48,14 @@ export const Header = ({
   const handleConnectClick = async () => {
     try {
       await connectSnap();
-      const snapInstalled = await isSnapInstalled();
+      const installedSnap = await getSnap();
 
       dispatch({
         type: MetamaskActions.SetInstalled,
-        payload: snapInstalled,
+        payload: {
+          isSnapInstalled: Boolean(installedSnap),
+          snap: installedSnap,
+        },
       });
     } catch (e) {
       console.error(e);

--- a/packages/site/src/components/Home.tsx
+++ b/packages/site/src/components/Home.tsx
@@ -2,7 +2,12 @@ import { useContext } from 'react';
 import styled from 'styled-components';
 import { MetamaskActions, MetaMaskContext } from '../hooks';
 import { connectSnap, isLocalSnap, getSnap, sendHello } from '../utils';
-import { ConnectButton, InstallFlaskButton, SendHelloButton } from './Buttons';
+import {
+  ConnectButton,
+  InstallFlaskButton,
+  ReconnectButton,
+  SendHelloButton,
+} from './Buttons';
 import { Card } from './Card';
 
 const Container = styled.div`
@@ -119,8 +124,8 @@ export const Home = () => {
     }
   };
 
-  const shouldDisplayConnectButton = () =>
-    state.snap ? isLocalSnap(state.snap?.id) || !state.isSnapInstalled : true;
+  const shouldDisplayReconnectButton = () =>
+    state.snap && isLocalSnap(state.snap?.id);
 
   return (
     <Container>
@@ -147,7 +152,7 @@ export const Home = () => {
             fullWidth
           />
         )}
-        {shouldDisplayConnectButton() && (
+        {!state.isSnapInstalled && (
           <Card
             content={{
               title: 'Connect',
@@ -163,6 +168,22 @@ export const Home = () => {
             disabled={!state.isFlask}
           />
         )}
+        {shouldDisplayReconnectButton() && (
+          <Card
+            content={{
+              title: 'Reconnect',
+              description:
+                'While connected to a local running snap this button will always be displayed in order to update the snap if a change is made.',
+              button: (
+                <ReconnectButton
+                  onClick={handleConnectClick}
+                  disabled={!state.isSnapInstalled}
+                />
+              ),
+            }}
+            disabled={!state.isSnapInstalled}
+          />
+        )}
         <Card
           content={{
             title: 'Send Hello message',
@@ -176,7 +197,12 @@ export const Home = () => {
             ),
           }}
           disabled={!state.isSnapInstalled}
-          fullWidth={state.isFlask && !shouldDisplayConnectButton()}
+          fullWidth={
+            state.isFlask &&
+            (state.snap && isLocalSnap(state.snap?.id)
+              ? !shouldDisplayReconnectButton()
+              : state.isSnapInstalled)
+          }
         />
         <Notice>
           <p>

--- a/packages/site/src/components/Home.tsx
+++ b/packages/site/src/components/Home.tsx
@@ -1,7 +1,12 @@
 import { useContext } from 'react';
 import styled from 'styled-components';
 import { MetamaskActions, MetaMaskContext } from '../hooks';
-import { connectSnap, isLocalSnap, getSnap, sendHello } from '../utils';
+import {
+  connectSnap,
+  getSnap,
+  sendHello,
+  shouldDisplayReconnectButton,
+} from '../utils';
 import {
   ConnectButton,
   InstallFlaskButton,
@@ -104,10 +109,7 @@ export const Home = () => {
 
       dispatch({
         type: MetamaskActions.SetInstalled,
-        payload: {
-          isSnapInstalled: Boolean(installedSnap),
-          snap: installedSnap,
-        },
+        payload: installedSnap,
       });
     } catch (e) {
       console.error(e);
@@ -123,9 +125,6 @@ export const Home = () => {
       dispatch({ type: MetamaskActions.SetError, payload: e });
     }
   };
-
-  const shouldDisplayReconnectButton = () =>
-    state.snap && isLocalSnap(state.snap?.id);
 
   return (
     <Container>
@@ -152,7 +151,7 @@ export const Home = () => {
             fullWidth
           />
         )}
-        {!state.isSnapInstalled && (
+        {!state.installedSnap && (
           <Card
             content={{
               title: 'Connect',
@@ -168,7 +167,7 @@ export const Home = () => {
             disabled={!state.isFlask}
           />
         )}
-        {shouldDisplayReconnectButton() && (
+        {shouldDisplayReconnectButton(state.installedSnap) && (
           <Card
             content={{
               title: 'Reconnect',
@@ -177,11 +176,11 @@ export const Home = () => {
               button: (
                 <ReconnectButton
                   onClick={handleConnectClick}
-                  disabled={!state.isSnapInstalled}
+                  disabled={!state.installedSnap}
                 />
               ),
             }}
-            disabled={!state.isSnapInstalled}
+            disabled={!state.installedSnap}
           />
         )}
         <Card
@@ -192,16 +191,16 @@ export const Home = () => {
             button: (
               <SendHelloButton
                 onClick={handleSendHelloClick}
-                disabled={!state.isSnapInstalled}
+                disabled={!state.installedSnap}
               />
             ),
           }}
-          disabled={!state.isSnapInstalled}
+          disabled={!state.installedSnap}
           fullWidth={
             state.isFlask &&
-            (state.snap && isLocalSnap(state.snap?.id)
-              ? !shouldDisplayReconnectButton()
-              : state.isSnapInstalled)
+            (shouldDisplayReconnectButton(state.installedSnap)
+              ? !shouldDisplayReconnectButton(state.installedSnap)
+              : Boolean(state.installedSnap))
           }
         />
         <Notice>

--- a/packages/site/src/components/Home.tsx
+++ b/packages/site/src/components/Home.tsx
@@ -198,9 +198,8 @@ export const Home = () => {
           disabled={!state.installedSnap}
           fullWidth={
             state.isFlask &&
-            (shouldDisplayReconnectButton(state.installedSnap)
-              ? !shouldDisplayReconnectButton(state.installedSnap)
-              : Boolean(state.installedSnap))
+            Boolean(state.installedSnap) &&
+            !shouldDisplayReconnectButton(state.installedSnap)
           }
         />
         <Notice>

--- a/packages/site/src/components/Home.tsx
+++ b/packages/site/src/components/Home.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import styled from 'styled-components';
 import { MetamaskActions, MetaMaskContext } from '../hooks';
-import { connectSnap, isSnapInstalled, sendHello } from '../utils';
+import { connectSnap, isLocalSnap, getSnap, sendHello } from '../utils';
 import { ConnectButton, InstallFlaskButton, SendHelloButton } from './Buttons';
 import { Card } from './Card';
 
@@ -95,11 +95,14 @@ export const Home = () => {
   const handleConnectClick = async () => {
     try {
       await connectSnap();
-      const snapInstalled = await isSnapInstalled();
+      const installedSnap = await getSnap();
 
       dispatch({
         type: MetamaskActions.SetInstalled,
-        payload: snapInstalled,
+        payload: {
+          isSnapInstalled: Boolean(installedSnap),
+          snap: installedSnap,
+        },
       });
     } catch (e) {
       console.error(e);
@@ -115,6 +118,9 @@ export const Home = () => {
       dispatch({ type: MetamaskActions.SetError, payload: e });
     }
   };
+
+  const shouldDisplayConnectButton = () =>
+    state.snap ? isLocalSnap(state.snap?.id) || !state.isSnapInstalled : true;
 
   return (
     <Container>
@@ -141,7 +147,7 @@ export const Home = () => {
             fullWidth
           />
         )}
-        {!state.isSnapInstalled && (
+        {shouldDisplayConnectButton() && (
           <Card
             content={{
               title: 'Connect',
@@ -170,7 +176,7 @@ export const Home = () => {
             ),
           }}
           disabled={!state.isSnapInstalled}
-          fullWidth={state.isFlask && state.isSnapInstalled}
+          fullWidth={state.isFlask && !shouldDisplayConnectButton()}
         />
         <Notice>
           <p>

--- a/packages/site/src/hooks/MetamaskContext.tsx
+++ b/packages/site/src/hooks/MetamaskContext.tsx
@@ -10,15 +10,12 @@ import { Snap } from '../types';
 import { isFlask, getSnap } from '../utils';
 
 export type MetamaskState = {
-  isSnapInstalled: boolean;
   isFlask: boolean;
-  snap?: Snap;
+  installedSnap?: Snap;
   error?: Error;
 };
 
 const initialState: MetamaskState = {
-  isSnapInstalled: false,
-  snap: undefined,
   isFlask: false,
   error: undefined,
 };
@@ -45,8 +42,7 @@ const reducer: Reducer<MetamaskState, MetamaskDispatch> = (state, action) => {
     case MetamaskActions.SetInstalled:
       return {
         ...state,
-        isSnapInstalled: action.payload.isSnapInstalled,
-        snap: action.payload.snap,
+        installedSnap: action.payload,
       };
 
     case MetamaskActions.SetFlaskDetected:
@@ -87,10 +83,10 @@ export const MetaMaskProvider = ({ children }: { children: ReactNode }) => {
     }
 
     async function detectSnapInstalled() {
-      const snap = await getSnap();
+      const installedSnap = await getSnap();
       dispatch({
         type: MetamaskActions.SetInstalled,
-        payload: { isSnapInstalled: Boolean(snap), snap },
+        payload: installedSnap,
       });
     }
 

--- a/packages/site/src/hooks/MetamaskContext.tsx
+++ b/packages/site/src/hooks/MetamaskContext.tsx
@@ -6,16 +6,19 @@ import {
   useEffect,
   useReducer,
 } from 'react';
-import { isFlask, isSnapInstalled } from '../utils';
+import { Snap } from '../types';
+import { isFlask, getSnap } from '../utils';
 
 export type MetamaskState = {
   isSnapInstalled: boolean;
   isFlask: boolean;
+  snap?: Snap;
   error?: Error;
 };
 
 const initialState: MetamaskState = {
   isSnapInstalled: false,
+  snap: undefined,
   isFlask: false,
   error: undefined,
 };
@@ -42,7 +45,8 @@ const reducer: Reducer<MetamaskState, MetamaskDispatch> = (state, action) => {
     case MetamaskActions.SetInstalled:
       return {
         ...state,
-        isSnapInstalled: action.payload,
+        isSnapInstalled: action.payload.isSnapInstalled,
+        snap: action.payload.snap,
       };
 
     case MetamaskActions.SetFlaskDetected:
@@ -83,10 +87,10 @@ export const MetaMaskProvider = ({ children }: { children: ReactNode }) => {
     }
 
     async function detectSnapInstalled() {
-      const snapInstalled = await isSnapInstalled();
+      const snap = await getSnap();
       dispatch({
         type: MetamaskActions.SetInstalled,
-        payload: snapInstalled,
+        payload: { isSnapInstalled: Boolean(snap), snap },
       });
     }
 

--- a/packages/site/src/types/index.ts
+++ b/packages/site/src/types/index.ts
@@ -1,1 +1,1 @@
-export { type GetSnapsResponse } from './snap';
+export { type GetSnapsResponse, type Snap } from './snap';

--- a/packages/site/src/types/snap.ts
+++ b/packages/site/src/types/snap.ts
@@ -1,8 +1,8 @@
-export type GetSnapsResponse = {
-  [k: string]: {
-    permissionName?: string;
-    id?: string;
-    version?: string;
-    initialPermissions?: { [k: string]: unknown };
-  };
+export type GetSnapsResponse = Record<string, Snap>;
+
+export type Snap = {
+  permissionName: string;
+  id: string;
+  version: string;
+  initialPermissions: Record<string, unknown>;
 };

--- a/packages/site/src/utils/button.ts
+++ b/packages/site/src/utils/button.ts
@@ -1,0 +1,5 @@
+import { Snap } from '../types';
+import { isLocalSnap } from './snap';
+
+export const shouldDisplayReconnectButton = (installedSnap?: Snap) =>
+  installedSnap && isLocalSnap(installedSnap?.id);

--- a/packages/site/src/utils/index.ts
+++ b/packages/site/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './metamask';
 export * from './snap';
 export * from './theme';
 export * from './localStorage';
+export * from './button';

--- a/packages/site/src/utils/snap.ts
+++ b/packages/site/src/utils/snap.ts
@@ -1,5 +1,5 @@
 import { defaultSnapOrigin } from '../config';
-import { GetSnapsResponse } from '../types';
+import { GetSnapsResponse, Snap } from '../types';
 
 /**
  * Get the installed snaps in MetaMask.
@@ -37,25 +37,22 @@ export const connectSnap = async (
 };
 
 /**
- * Check if a snap is already installed in MetaMask.
+ * Get the snap from MetaMask.
  *
  * @param version - The version of the snap to install (optional).
- * @returns A boolean representing if the snap is installed in MetaMask.
+ * @returns The snap object returned by the extension.
  */
-export const isSnapInstalled = async (version?: string): Promise<boolean> => {
+export const getSnap = async (version?: string): Promise<Snap | undefined> => {
   try {
     const snaps = await getSnaps();
 
-    return Boolean(
-      Object.values(snaps).find(
-        (snap) =>
-          snap.id === defaultSnapOrigin &&
-          (!version || snap.version === version),
-      ),
+    return Object.values(snaps).find(
+      (snap) =>
+        snap.id === defaultSnapOrigin && (!version || snap.version === version),
     );
   } catch (e) {
-    console.log('Failed to obtain installed snaps', e);
-    return false;
+    console.log('Failed to obtain installed snap', e);
+    return undefined;
   }
 };
 
@@ -74,3 +71,5 @@ export const sendHello = async () => {
     ],
   });
 };
+
+export const isLocalSnap = (snapId: string) => snapId.startsWith('local:');


### PR DESCRIPTION
Always show a re-connect button if the utilized snap is a local snap.

Fixes partially: https://github.com/MetaMask/snaps-skunkworks/issues/763