### PR TITLE
Hotfix: Always show and enable the `send hello` button.

### DIFF
--- a/packages/site/src/components/Home.tsx
+++ b/packages/site/src/components/Home.tsx
@@ -191,16 +191,12 @@ export const Home = () => {
             button: (
               <SendHelloButton
                 onClick={handleSendHelloClick}
-                disabled={!state.installedSnap}
+                disabled={false}
               />
             ),
           }}
-          disabled={!state.installedSnap}
-          fullWidth={
-            state.isFlask &&
-            Boolean(state.installedSnap) &&
-            !shouldDisplayReconnectButton(state.installedSnap)
-          }
+          disabled={false}
+          fullWidth={false}
         />
         <Notice>
           <p>


### PR DESCRIPTION
Hotfix for broken `wallet_getSnaps` in MetaMask Flask 10.20.0