### PR TITLE
Make `Card` component more flexible

### DIFF
--- a/packages/site/src/components/Card.tsx
+++ b/packages/site/src/components/Card.tsx
@@ -49,7 +49,9 @@ export const Card = ({ content, disabled = false, fullWidth }: CardProps) => {
   const { title, description, button } = content;
   return (
     <CardWrapper fullWidth={fullWidth} disabled={disabled}>
-      <Title>{title}</Title>
+      {title && (
+        <Title>{title}</Title>
+      )}
       <Description>{description}</Description>
       {button}
     </CardWrapper>

--- a/packages/site/src/components/Card.tsx
+++ b/packages/site/src/components/Card.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 type CardProps = {
   content: {
     title?: string;
-    description: string | ReactNode;
+    description: ReactNode;
     button?: ReactNode;
   };
   disabled?: boolean;

--- a/packages/site/src/components/Card.tsx
+++ b/packages/site/src/components/Card.tsx
@@ -3,9 +3,9 @@ import styled from 'styled-components';
 
 type CardProps = {
   content: {
-    title: string;
-    description: string;
-    button: ReactNode;
+    title?: string;
+    description: string | ReactNode;
+    button?: ReactNode;
   };
   disabled?: boolean;
   fullWidth?: boolean;
@@ -40,7 +40,7 @@ const Title = styled.h2`
   }
 `;
 
-const Description = styled.p`
+const Description = styled.div`
   margin-top: 2.4rem;
   margin-bottom: 2.4rem;
 `;


### PR DESCRIPTION
This makes it easy to use the card component for building forms, showing long form content, etc. This change made it easy to build the dapp for the Web3 Unleashed NFT Vault dapp. 