### PR TITLE
Added JSON schema linting for manifest files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "json.schemas": [
+    {
+      "fileMatch": ["snap.manifest.json"],
+      "url": "https://raw.githubusercontent.com/MetaMask/SIPs/main/assets/sip-9/snap.manifest.schema.json"
+    }
+  ]
+}


### PR DESCRIPTION
Added VSCode settings file that enables linting `snap.manifest.json` files using our schema.

Preferably we would use `$schema` property in the JSON file itself, but that would make it fail superstruct validation in v1 release version. I've added a PR to fix that - https://github.com/MetaMask/snaps-monorepo/pull/1389, but it has to wait after we release feature freeze.

**This PR requires https://github.com/MetaMask/SIPs/pull/93 to be merged beforehand**