### PR TITLE
chore: improve SNAP_ORIGIN documentation

### DIFF
--- a/packages/site/.env.production.dist
+++ b/packages/site/.env.production.dist
@@ -1,1 +1,4 @@
+/**
+ * To use this, rename to `.env.production` and set the production SNAP_ORIGIN here
+ */
 SNAP_ORIGIN=

--- a/packages/site/src/config/snap.ts
+++ b/packages/site/src/config/snap.ts
@@ -1,6 +1,10 @@
 /**
  * The snap origin to use.
  * Will default to the local hosted snap if no value is provided in environment.
+ *
+ * You may be tempted to change this to the URL where your production snap is hosted, but please
+ * don't. Instead, rename `.env.production.dist` to `.env.production` and set the production URL
+ * there. Running `yarn build` will automatically use the production environment variables.
  */
 export const defaultSnapOrigin =
   process.env.SNAP_ORIGIN ?? `local:http://localhost:8080`;


### PR DESCRIPTION
The documentation for how to set SNAP_ORIGIN in order to support local development and production versions was a little unclear, and the Accounts team misinterpreted it (see MetaMask/snap-simple-keyring#59)

In this PR, I have tried to make it a little clearer