### PR TITLE
build: package.json now requires node>=18

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
   },
   "packageManager": "yarn@3.2.1",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
mm snap requires node latest lts version (which is 18 currently)

`package.json`  on the root says `node>=16`, so I updated it to 18