### PR TITLE
Add prepublishOnly script with Snap manifest validation

### DIFF
--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -22,6 +22,7 @@
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path .gitignore",
+    "prepublishOnly": "mm-snap manifest",
     "serve": "mm-snap serve",
     "start": "mm-snap watch",
     "test": "jest"


### PR DESCRIPTION
Adds `mm-snap manifest` as a `prepublishOnly` script in the `/snaps` package to prevent publishing snaps with invalid manifests (especially invalid shasums).