### PR TITLE
Support EIP-6963

### DIFF
--- a/packages/site/src/components/Header.tsx
+++ b/packages/site/src/components/Header.tsx
@@ -44,12 +44,12 @@ export const Header = ({
   handleToggleClick(): void;
 }) => {
   const theme = useTheme();
-  const [state, dispatch] = useContext(MetaMaskContext);
+  const { state, dispatch, provider } = useContext(MetaMaskContext);
 
   const handleConnectClick = async () => {
     try {
-      await connectSnap();
-      const installedSnap = await getSnap();
+      await connectSnap(provider!);
+      const installedSnap = await getSnap(provider!);
 
       dispatch({
         type: MetamaskActions.SetInstalled,

--- a/packages/site/src/components/Header.tsx
+++ b/packages/site/src/components/Header.tsx
@@ -48,7 +48,10 @@ export const Header = ({
 
   const handleConnectClick = async () => {
     try {
+      // This function will only be triggerable if a provider is available
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       await connectSnap(provider!);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const installedSnap = await getSnap(provider!);
 
       dispatch({

--- a/packages/site/src/hooks/MetamaskContext.tsx
+++ b/packages/site/src/hooks/MetamaskContext.tsx
@@ -1,9 +1,9 @@
+import type { MetaMaskInpageProvider } from '@metamask/providers';
 import type { Dispatch, ReactNode, Reducer } from 'react';
 import { createContext, useEffect, useReducer, useState } from 'react';
 
 import type { Snap } from '../types';
 import { getSnapsProvider, getSnap, isFlask } from '../utils';
-import type { MetaMaskInpageProvider } from '@metamask/providers';
 
 export type MetamaskState = {
   snapsDetected: boolean;
@@ -88,16 +88,24 @@ export const MetaMaskProvider = ({ children }: { children: ReactNode }) => {
   // Find MetaMask Provider and search for Snaps
   // Also checks if MetaMask version is Flask
   useEffect(() => {
+    /**
+     * Detect if the Snap is installed and set the result it in state.
+     */
     async function detectSnapInstalled() {
       dispatch({
         type: MetamaskActions.SetInstalled,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         payload: await getSnap(provider!),
       });
     }
 
+    /**
+     * Detect if the provider is Flask and set the result it in state.
+     */
     async function checkIfFlask() {
       dispatch({
         type: MetamaskActions.SetIsFlask,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         payload: await isFlask(provider!),
       });
     }

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -111,7 +111,10 @@ const Index = () => {
 
   const handleConnectClick = async () => {
     try {
+      // This function will only be triggerable if a provider is available
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       await connectSnap(provider!);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const installedSnap = await getSnap(provider!);
 
       dispatch({
@@ -126,6 +129,8 @@ const Index = () => {
 
   const handleSendHelloClick = async () => {
     try {
+      // This function will only be triggerable if a provider is available
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       await sendHello(provider!);
     } catch (error) {
       console.error(error);

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -103,7 +103,7 @@ const ErrorMessage = styled.div`
 `;
 
 const Index = () => {
-  const [state, dispatch] = useContext(MetaMaskContext);
+  const { state, dispatch, provider } = useContext(MetaMaskContext);
 
   const isMetaMaskReady = isLocalSnap(defaultSnapOrigin)
     ? state.isFlask
@@ -111,8 +111,8 @@ const Index = () => {
 
   const handleConnectClick = async () => {
     try {
-      await connectSnap();
-      const installedSnap = await getSnap();
+      await connectSnap(provider!);
+      const installedSnap = await getSnap(provider!);
 
       dispatch({
         type: MetamaskActions.SetInstalled,
@@ -126,7 +126,7 @@ const Index = () => {
 
   const handleSendHelloClick = async () => {
     try {
-      await sendHello();
+      await sendHello(provider!);
     } catch (error) {
       console.error(error);
       dispatch({ type: MetamaskActions.SetError, payload: error });

--- a/packages/site/src/types/custom.d.ts
+++ b/packages/site/src/types/custom.d.ts
@@ -1,16 +1,25 @@
-/* eslint-disable */
-
-import { MetaMaskInpageProvider } from '@metamask/providers';
+import type {
+  EIP6963AnnounceProviderEvent,
+  EIP6963RequestProviderEvent,
+  MetaMaskInpageProvider,
+} from '@metamask/providers';
 
 /*
  * Window type extension to support ethereum
  */
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Window {
     ethereum: MetaMaskInpageProvider & {
       setProvider?: (provider: MetaMaskInpageProvider) => void;
       detected?: MetaMaskInpageProvider[];
       providers?: MetaMaskInpageProvider[];
     };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+  interface WindowEventMap {
+    'eip6963:requestProvider': EIP6963RequestProviderEvent;
+    'eip6963:announceProvider': EIP6963AnnounceProviderEvent;
   }
 }

--- a/packages/site/src/utils/metamask.ts
+++ b/packages/site/src/utils/metamask.ts
@@ -58,9 +58,10 @@ export async function getMetaMaskEIP6963Provider() {
      * Resolves the promise if a MetaMask provider is found.
      *
      * @param event - The EIP6963 announceProvider event.
+     * @param event.detail - The details of the EIP6963 announceProvider event.
      */
-    function onAnnounceProvider(event: EIP6963AnnounceProviderEvent) {
-      const { info, provider } = event.detail;
+    function onAnnounceProvider({ detail }: EIP6963AnnounceProviderEvent) {
+      const { info, provider } = detail;
 
       if (info.rdns.includes('io.metamask')) {
         resolve(provider);
@@ -116,6 +117,7 @@ export async function getSnapsProvider() {
 /**
  * Detect if the wallet injecting the ethereum object is MetaMask Flask.
  *
+ * @param provider - The MetaMask inpage provider.
  * @returns True if the MetaMask version is Flask, false otherwise.
  */
 export const isFlask = async (provider = window.ethereum) => {

--- a/packages/site/src/utils/metamask.ts
+++ b/packages/site/src/utils/metamask.ts
@@ -1,61 +1,124 @@
-import { getSnaps } from './snap';
+import type {
+  EIP6963AnnounceProviderEvent,
+  MetaMaskInpageProvider,
+} from '@metamask/providers';
 
 /**
- * Tries to detect if one of the injected providers is MetaMask and checks if snaps is available in that MetaMask version.
+ * Check if the current provider supports snaps by calling `wallet_getSnaps`.
  *
- * @returns True if the MetaMask version supports Snaps, false otherwise.
+ * @param provider - The provider to use to check for snaps support. Defaults to
+ * `window.ethereum`.
+ * @returns True if the provider supports snaps, false otherwise.
  */
-export const detectSnaps = async () => {
+export async function hasSnapsSupport(
+  provider: MetaMaskInpageProvider = window.ethereum,
+) {
+  try {
+    await provider.request({
+      method: 'wallet_getSnaps',
+    });
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get a MetaMask provider using EIP6963. This will return the first provider
+ * reporting as MetaMask. If no provider is found after 500ms, this will
+ * return null instead.
+ *
+ * @returns A MetaMask provider if found, otherwise null.
+ */
+export async function getMetaMaskEIP6963Provider() {
+  return new Promise<MetaMaskInpageProvider | null>((rawResolve) => {
+    // Timeout looking for providers after 500ms
+    const timeout = setTimeout(() => {
+      resolve(null);
+    }, 500);
+
+    /**
+     * Resolve the promise with a MetaMask provider and clean up.
+     *
+     * @param provider - A MetaMask provider if found, otherwise null.
+     */
+    function resolve(provider: MetaMaskInpageProvider | null) {
+      window.removeEventListener(
+        'eip6963:announceProvider',
+        onAnnounceProvider,
+      );
+      clearTimeout(timeout);
+      rawResolve(provider);
+    }
+
+    /**
+     * Listener for the EIP6963 announceProvider event.
+     *
+     * Resolves the promise if a MetaMask provider is found.
+     *
+     * @param event - The EIP6963 announceProvider event.
+     */
+    function onAnnounceProvider(event: EIP6963AnnounceProviderEvent) {
+      const { info, provider } = event.detail;
+
+      if (info.rdns.includes('io.metamask')) {
+        resolve(provider);
+      }
+    }
+
+    window.addEventListener('eip6963:announceProvider', onAnnounceProvider);
+
+    window.dispatchEvent(new Event('eip6963:requestProvider'));
+  });
+}
+
+/**
+ * Get a provider that supports snaps. This will loop through all the detected
+ * providers and return the first one that supports snaps.
+ *
+ * @returns The provider, or `null` if no provider supports snaps.
+ */
+export async function getSnapsProvider() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  if (await hasSnapsSupport()) {
+    return window.ethereum;
+  }
+
   if (window.ethereum?.detected) {
     for (const provider of window.ethereum.detected) {
-      try {
-        // Detect snaps support
-        await getSnaps(provider);
-
-        // enforces MetaMask as provider
-        if (window.ethereum.setProvider) {
-          window.ethereum.setProvider(provider);
-        }
-
-        return true;
-      } catch {
-        // no-op
+      if (await hasSnapsSupport(provider)) {
+        return provider;
       }
     }
   }
 
   if (window.ethereum?.providers) {
     for (const provider of window.ethereum.providers) {
-      try {
-        // Detect snaps support
-        await getSnaps(provider);
-
-        window.ethereum = provider;
-
-        return true;
-      } catch {
-        // no-op
+      if (await hasSnapsSupport(provider)) {
+        return provider;
       }
     }
   }
 
-  try {
-    await getSnaps();
+  const eip6963Provider = await getMetaMaskEIP6963Provider();
 
-    return true;
-  } catch {
-    return false;
+  if (eip6963Provider && (await hasSnapsSupport(eip6963Provider))) {
+    return eip6963Provider;
   }
-};
+
+  return null;
+}
 
 /**
  * Detect if the wallet injecting the ethereum object is MetaMask Flask.
  *
  * @returns True if the MetaMask version is Flask, false otherwise.
  */
-export const isFlask = async () => {
-  const provider = window.ethereum;
-
+export const isFlask = async (provider = window.ethereum) => {
   try {
     const clientVersion = await provider?.request({
       method: 'web3_clientVersion',

--- a/packages/site/src/utils/snap.ts
+++ b/packages/site/src/utils/snap.ts
@@ -10,22 +10,24 @@ import type { GetSnapsResponse, Snap } from '../types';
  * @returns The snaps installed in MetaMask.
  */
 export const getSnaps = async (
-  provider?: MetaMaskInpageProvider,
+  provider: MetaMaskInpageProvider,
 ): Promise<GetSnapsResponse> =>
-  (await (provider ?? window.ethereum).request({
+  (await provider.request({
     method: 'wallet_getSnaps',
   })) as unknown as GetSnapsResponse;
 /**
  * Connect a snap to MetaMask.
  *
+ * @param provider - The MetaMask inpage provider.
  * @param snapId - The ID of the snap.
  * @param params - The params to pass with the snap to connect.
  */
 export const connectSnap = async (
+  provider: MetaMaskInpageProvider,
   snapId: string = defaultSnapOrigin,
   params: Record<'version' | string, unknown> = {},
 ) => {
-  await window.ethereum.request({
+  await provider.request({
     method: 'wallet_requestSnaps',
     params: {
       [snapId]: params,
@@ -39,9 +41,12 @@ export const connectSnap = async (
  * @param version - The version of the snap to install (optional).
  * @returns The snap object returned by the extension.
  */
-export const getSnap = async (version?: string): Promise<Snap | undefined> => {
+export const getSnap = async (
+  provider: MetaMaskInpageProvider,
+  version?: string,
+): Promise<Snap | undefined> => {
   try {
-    const snaps = await getSnaps();
+    const snaps = await getSnaps(provider);
 
     return Object.values(snaps).find(
       (snap) =>
@@ -55,10 +60,11 @@ export const getSnap = async (version?: string): Promise<Snap | undefined> => {
 
 /**
  * Invoke the "hello" method from the example snap.
+ * @param provider - The MetaMask inpage provider.
  */
 
-export const sendHello = async () => {
-  await window.ethereum.request({
+export const sendHello = async (provider: MetaMaskInpageProvider) => {
+  await provider.request({
     method: 'wallet_invokeSnap',
     params: { snapId: defaultSnapOrigin, request: { method: 'hello' } },
   });

--- a/packages/site/src/utils/snap.ts
+++ b/packages/site/src/utils/snap.ts
@@ -38,6 +38,7 @@ export const connectSnap = async (
 /**
  * Get the snap from MetaMask.
  *
+ * @param provider - The MetaMask inpage provider.
  * @param version - The version of the snap to install (optional).
  * @returns The snap object returned by the extension.
  */


### PR DESCRIPTION
Adds support for detecting provider via EIP-6963. This PR also refactors the provider logic across the app slightly to decouple from the `window.ethereum` global.

Closes #128 