### PR TITLE
Fix Firefox incompatibility issues

### DIFF
--- a/packages/site/src/hooks/useRequestSnap.ts
+++ b/packages/site/src/hooks/useRequestSnap.ts
@@ -25,12 +25,12 @@ export const useRequestSnap = (
     const snaps = (await request({
       method: 'wallet_requestSnaps',
       params: {
-        [snapId]: { version },
+        [snapId]: version ? { version } : {},
       },
     })) as Record<string, Snap>;
 
     // Updates the `installedSnap` context variable since we just installed the Snap.
-    setInstalledSnap(snaps[snapId] ?? null);
+    setInstalledSnap(snaps?.[snapId] ?? null);
   };
 
   return requestSnap;


### PR DESCRIPTION
This PR fixes two problems:
- Firstly, we were passing `undefined` as the version, which breaks in Firefox causing installation to be impossible.
- Secondly, an unhandled error would occur if the user rejected installation, this case is now handled.