### PR TITLE
Add params to invokeSnap

### DIFF
--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -111,7 +111,7 @@ const Index = () => {
     : snapsDetected;
 
   const handleSendHelloClick = async () => {
-    await invokeSnap({ method: 'hello' });
+    await invokeSnap({ method: 'hello', params: {} });
   };
 
   return (


### PR DESCRIPTION
User experiences this message when walking through tutorial

![](https://raw.githubusercontent.com/MetaMask/metamask-docs/32565387ebac05029242a48d1e460bdbfe9366d1/snaps/assets/snaps-error-gas-estimation.png)

Adding params to by pass troubleshooting 