### PR TITLE
Fix `invokeSnap` in Firefox

### DIFF
--- a/packages/site/src/hooks/useInvokeSnap.ts
+++ b/packages/site/src/hooks/useInvokeSnap.ts
@@ -29,10 +29,7 @@ export const useInvokeSnap = (snapId = defaultSnapOrigin) => {
       method: 'wallet_invokeSnap',
       params: {
         snapId,
-        request: {
-          method,
-          params,
-        },
+        request: params ? { method, params } : { method },
       },
     });
 


### PR DESCRIPTION
Fixes a problem where invoking the Snap would fail in Firefox.