### PR TITLE
Bump `ws` from `8.11.0` to `8.17.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test": "yarn workspace snap run test"
   },
   "resolutions": {
-    "sharp": "^0.33.5"
+    "sharp": "^0.33.5",
+    "ws": "^8.17.1"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19342,33 +19342,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^7.3.1":
-  version: 7.5.10
-  resolution: "ws@npm:7.5.10"
+"ws@npm:^8.17.1":
+  version: 8.18.2
+  resolution: "ws@npm:8.18.2"
   peerDependencies:
     bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
+    utf-8-validate: ">=5.0.2"
   peerDependenciesMeta:
     bufferutil:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: f9bb062abf54cc8f02d94ca86dcd349c3945d63851f5d07a3a61c2fcb755b15a88e943a63cf580cbdb5b74436d67ef6b67f745b8f7c0814e411379138e1863cb
-  languageName: node
-  linkType: hard
-
-"ws@npm:~8.11.0":
-  version: 8.11.0
-  resolution: "ws@npm:8.11.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 316b33aba32f317cd217df66dbfc5b281a2f09ff36815de222bc859e3424d83766d9eb2bd4d667de658b6ab7be151f258318fb1da812416b30be13103e5b5c67
+  checksum: e38beae19ba4d68577ec24eb34fbfab376333fedd10f99b07511a8e842e22dbc102de39adac333a18e4c58868d0703cd5f239b04b345e22402d0ed8c34ea0aa0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This bumps `ws` from `8.11.0` to `8.17.1` to resolve [this Dependabot alert](https://github.com/MetaMask/template-snap-monorepo/security/dependabot/41). Unfortunately Gatsby is pinned to `8.11.0` so I had to add a resolution.