### PR TITLE
Bump `path-to-regexp` from `0.1.10` to `0.1.12`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "resolutions": {
     "cookie": "^0.7.1",
+    "path-to-regexp": "^0.1.12",
     "sharp": "^0.33.5",
     "socket.io": "^4.8.1",
     "ws": "^8.17.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15575,24 +15575,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:0.1.10":
-  version: 0.1.10
-  resolution: "path-to-regexp@npm:0.1.10"
-  checksum: ab7a3b7a0b914476d44030340b0a65d69851af2a0f33427df1476100ccb87d409c39e2182837a96b98fb38c4ef2ba6b87bdad62bb70a2c153876b8061760583c
-  languageName: node
-  linkType: hard
-
-"path-to-regexp@npm:0.1.12":
+"path-to-regexp@npm:^0.1.12":
   version: 0.1.12
   resolution: "path-to-regexp@npm:0.1.12"
   checksum: ab237858bee7b25ecd885189f175ab5b5161e7b712b360d44f5c4516b8d271da3e4bf7bf0a7b9153ecb04c7d90ce8ff5158614e1208819cf62bac2b08452722e
-  languageName: node
-  linkType: hard
-
-"path-to-regexp@npm:^8.0.0":
-  version: 8.2.0
-  resolution: "path-to-regexp@npm:8.2.0"
-  checksum: 56e13e45962e776e9e7cd72e87a441cfe41f33fd539d097237ceb16adc922281136ca12f5a742962e33d8dda9569f630ba594de56d8b7b6e49adf31803c5e771
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This bumps `path-to-regexp` from `0.1.10` to `0.1.12` to resolve [this Dependabot alert](https://github.com/MetaMask/template-snap-monorepo/security/dependabot/62). Unfortunately Gatsby is pinned to `0.1.10` so I had to add a resolution.